### PR TITLE
View single cab, closes #18

### DIFF
--- a/dev/user.clj
+++ b/dev/user.clj
@@ -2,6 +2,8 @@
   (:require [mount.core :as mount]
             [clojure.tools.namespace.repl :refer [refresh]]))
 
+(clojure.tools.namespace.repl/set-refresh-dirs "src" "test")
+
 #_:clj-kondo/ignore
 (defn restart-server []
   (mount/stop)

--- a/src/winter_onboarding_2021/fleet_management_service/core.clj
+++ b/src/winter_onboarding_2021/fleet_management_service/core.clj
@@ -40,6 +40,7 @@
   :stop (stop-server server))
 
 (defn -main [command & rest]
+  (println "holaa" command)
   (if (= "migrations" command)
     (apply migration/run-migratus rest)
     (mount/start)))

--- a/src/winter_onboarding_2021/fleet_management_service/core.clj
+++ b/src/winter_onboarding_2021/fleet_management_service/core.clj
@@ -40,7 +40,6 @@
   :stop (stop-server server))
 
 (defn -main [command & rest]
-  (println "holaa" command)
   (if (= "migrations" command)
     (apply migration/run-migratus rest)
     (mount/start)))

--- a/src/winter_onboarding_2021/fleet_management_service/handlers/cab.clj
+++ b/src/winter_onboarding_2021/fleet_management_service/handlers/cab.clj
@@ -22,8 +22,11 @@
       (-> error-flash
           (assoc-in [:flash :data] multipart-params)
           (merge (response/redirect "/cabs/new")))
-      (do (cab-model/create validated-cab)
-          (merge success-flash (response/redirect "/cabs/new"))))))
+      (let [created-cab (cab-model/create validated-cab)]
+        (merge success-flash (response/redirect
+                              (format
+                               "/cabs/%s"
+                               (:cabs/id created-cab))))))))
 
 (defn new [request]
   (response/response

--- a/src/winter_onboarding_2021/fleet_management_service/handlers/cab.clj
+++ b/src/winter_onboarding_2021/fleet_management_service/handlers/cab.clj
@@ -1,9 +1,9 @@
 (ns winter-onboarding-2021.fleet-management-service.handlers.cab
   (:require [ring.util.response :as response]
             [clojure.spec.alpha :as s]
-            [winter-onboarding-2021.fleet-management-service.models.cab :as cab-model]
+            [winter-onboarding-2021.fleet-management-service.models.cab :as models]
             [winter-onboarding-2021.fleet-management-service.views.layout :as layout]
-            [winter-onboarding-2021.fleet-management-service.views.cab :as cab-views]
+            [winter-onboarding-2021.fleet-management-service.views.cab :as views]
             [winter-onboarding-2021.fleet-management-service.specs :as specs]))
 
 (def error-flash
@@ -22,7 +22,7 @@
       (-> error-flash
           (assoc-in [:flash :data] multipart-params)
           (merge (response/redirect "/cabs/new")))
-      (let [created-cab (cab-model/create validated-cab)]
+      (let [created-cab (models/create validated-cab)]
         (merge success-flash (response/redirect
                               (format
                                "/cabs/%s"
@@ -33,13 +33,13 @@
    (layout/application
     request
     "Add a cab"
-    (cab-views/cab-form
+    (views/cab-form
      (get-in request [:flash :data])))))
 
 (defn view-cab [request]
-  (let [cab (cab-model/get-by-id (get-in request [:params :slug]))]
+  (let [cab (models/get-by-id (get-in request [:params :id]))]
     (response/response
      (layout/application
       request
       (:cabs/name cab)
-      (cab-views/single-cab cab)))))
+      (views/cab cab)))))

--- a/src/winter_onboarding_2021/fleet_management_service/handlers/cab.clj
+++ b/src/winter_onboarding_2021/fleet_management_service/handlers/cab.clj
@@ -32,3 +32,11 @@
     "Add a cab"
     (cab-views/cab-form
      (get-in request [:flash :data])))))
+
+(defn view-cab [request]
+  (let [cab (cab-model/get-by-id (get-in request [:params :slug]))]
+    (response/response
+     (layout/application
+      request
+      (:cabs/name cab)
+      (cab-views/single-cab cab)))))

--- a/src/winter_onboarding_2021/fleet_management_service/models/cab.clj
+++ b/src/winter_onboarding_2021/fleet_management_service/models/cab.clj
@@ -11,3 +11,9 @@
                  :cabs
                  (java.util.UUID/fromString id)
                  m-core/sql-opts))
+
+(defn find-by-keys [key-map]
+  (sql/find-by-keys db/db-conn
+                    :cabs
+                    key-map
+                    m-core/sql-opts))

--- a/src/winter_onboarding_2021/fleet_management_service/models/cab.clj
+++ b/src/winter_onboarding_2021/fleet_management_service/models/cab.clj
@@ -1,6 +1,13 @@
 (ns winter-onboarding-2021.fleet-management-service.models.cab
   (:require [winter-onboarding-2021.fleet-management-service.db.core :as db]
-            [winter-onboarding-2021.fleet-management-service.models.core :as m-core]))
+            [winter-onboarding-2021.fleet-management-service.models.core :as m-core]
+            [next.jdbc.sql :as sql]))
 
 (defn create [cab]
   (m-core/insert! db/db-conn :cabs cab))
+
+(defn get-by-id [id]
+  (sql/get-by-id db/db-conn
+                 :cabs
+                 (java.util.UUID/fromString id)
+                 m-core/sql-opts))

--- a/src/winter_onboarding_2021/fleet_management_service/routes.clj
+++ b/src/winter_onboarding_2021/fleet_management_service/routes.clj
@@ -8,7 +8,7 @@
   ["/" [["public" {:get (br/->Resources {:prefix "/bootstrap"})}]
         ["cabs/" {"" {:post cab/create}
                   "new" {:get cab/new}
-                  ["" :slug] {:get cab/view-cab}}]
+                  [:id] {:get cab/view-cab}}]
         ["healthcheck" {:get (wrap-json-response handler/health-check)}]
         ["index" {:get handler/index}]
         [true (fn [_] {:status 404 :body "Not found"})]]])

--- a/src/winter_onboarding_2021/fleet_management_service/routes.clj
+++ b/src/winter_onboarding_2021/fleet_management_service/routes.clj
@@ -6,8 +6,9 @@
 
 (def routes
   ["/" [["public" {:get (br/->Resources {:prefix "/bootstrap"})}]
-        ["cabs" {:post {"/" cab/create}
-                 :get {"/new" cab/new}}]
-        ["healthcheck" {:get (wrap-json-response handler/health-check)}]
+        ["cabs/" {"" {:post cab/create}
+                  "new" {:get cab/new}
+                  ["" :slug] {:get cab/view-cab}}
+         ["healthcheck" {:get (wrap-json-response handler/health-check)}]]
         ["index" {:get handler/index}]
         [true (fn [_] {:status 404 :body "Not found"})]]])

--- a/src/winter_onboarding_2021/fleet_management_service/routes.clj
+++ b/src/winter_onboarding_2021/fleet_management_service/routes.clj
@@ -8,7 +8,7 @@
   ["/" [["public" {:get (br/->Resources {:prefix "/bootstrap"})}]
         ["cabs/" {"" {:post cab/create}
                   "new" {:get cab/new}
-                  ["" :slug] {:get cab/view-cab}}
-         ["healthcheck" {:get (wrap-json-response handler/health-check)}]]
+                  ["" :slug] {:get cab/view-cab}}]
+        ["healthcheck" {:get (wrap-json-response handler/health-check)}]
         ["index" {:get handler/index}]
         [true (fn [_] {:status 404 :body "Not found"})]]])

--- a/src/winter_onboarding_2021/fleet_management_service/views/cab.clj
+++ b/src/winter_onboarding_2021/fleet_management_service/views/cab.clj
@@ -31,3 +31,13 @@
       :required true
       :value distance_travelled)]
     [:button {:type "submit" :class "btn btn-primary"} "Submit"]]])
+
+(defn single-cab [cab]
+  [:div {:id "content" :class "p-5"}
+   [:h2 (:cabs/name cab)]
+   [:div {:class "mt-5"}
+    [:div "Licence Plate"]
+    [:h3 (:cabs/licence-plate cab)]]
+   [:div {:class "mt-5"}
+    [:div "Distance Travlled"]
+    [:h3 (:cabs/distance-travelled cab)]]])

--- a/src/winter_onboarding_2021/fleet_management_service/views/cab.clj
+++ b/src/winter_onboarding_2021/fleet_management_service/views/cab.clj
@@ -32,7 +32,7 @@
       :value distance_travelled)]
     [:button {:type "submit" :class "btn btn-primary"} "Submit"]]])
 
-(defn single-cab [cab]
+(defn cab [cab]
   [:div {:id "content" :class "p-5"}
    [:h2 (:cabs/name cab)]
    [:div {:class "mt-5"}

--- a/test/winter_onboarding_2021/fleet_management/handlers/cab_test.clj
+++ b/test/winter_onboarding_2021/fleet_management/handlers/cab_test.clj
@@ -24,9 +24,8 @@
               :message "Cab added successfully!"}
              (:flash response)))
 
-      (is (= true (-> response
-                      (get-in [:headers "Location"])
-                      (= (str "/cabs/" (:cabs/id cab))))))
+      (is (= (str "/cabs/" (:cabs/id cab))
+             (get-in response [:headers "Location"])))
 
       (is (= "" (:body response))))))
 

--- a/test/winter_onboarding_2021/fleet_management/handlers/cab_test.clj
+++ b/test/winter_onboarding_2021/fleet_management/handlers/cab_test.clj
@@ -1,6 +1,5 @@
 (ns winter-onboarding-2021.fleet-management.handlers.cab-test
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
-            [clojure.string :as str]
             [winter-onboarding-2021.fleet-management-service.handlers.cab :as handlers]
             [winter-onboarding-2021.fleet-management-service.views.cab :as views]
             [winter-onboarding-2021.fleet-management-service.models.cab :as models]
@@ -15,7 +14,9 @@
     (let [response (handlers/create {:multipart-params
                                      {:name "Test cab"
                                       :licence_plate "KA20X1234"
-                                      :distance_travelled "1223"}})]
+                                      :distance_travelled "1223"}})
+          cab (first (models/find-by-keys {:licence-plate "KA20X1234"}))]
+
       (is (= 302 (:status response)))
 
       (is (= {:success true
@@ -25,10 +26,7 @@
 
       (is (= true (-> response
                       (get-in [:headers "Location"])
-                      (str/split #"/") ; Could be better if we use regex
-                      (nth 2)
-                      count
-                      (= 36))))
+                      (= (str "/cabs/" (:cabs/id cab))))))
 
       (is (= "" (:body response))))))
 

--- a/test/winter_onboarding_2021/fleet_management/handlers/cab_test.clj
+++ b/test/winter_onboarding_2021/fleet_management/handlers/cab_test.clj
@@ -51,9 +51,9 @@
                               :distance-travelled 19191})
           output-html (layout/application {}
                                           (:cabs/name cab)
-                                          (views/single-cab cab))]
+                                          (views/cab cab))]
       (is (= {:status 200
               :body output-html}
-             (-> {:params {:slug (str (:cabs/id cab))}}
+             (-> {:params {:id (str (:cabs/id cab))}}
                  handlers/view-cab
                  (select-keys [:status :body])))))))

--- a/test/winter_onboarding_2021/fleet_management/handlers/cab_test.clj
+++ b/test/winter_onboarding_2021/fleet_management/handlers/cab_test.clj
@@ -1,6 +1,9 @@
 (ns winter-onboarding-2021.fleet-management.handlers.cab-test
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
-            [winter-onboarding-2021.fleet-management-service.handlers.cab :as cab]
+            [winter-onboarding-2021.fleet-management-service.handlers.cab :as handlers]
+            [winter-onboarding-2021.fleet-management-service.views.cab :as views]
+            [winter-onboarding-2021.fleet-management-service.models.cab :as models]
+            [winter-onboarding-2021.fleet-management-service.views.layout :as layout]
             [winter-onboarding-2021.fleet-management.fixtures :as fixtures]))
 
 (use-fixtures :once fixtures/config fixtures/db-connection)
@@ -14,9 +17,9 @@
                     :message "Cab added successfully!"}
             :headers {"Location" "/cabs/new"}
             :body ""}
-           (cab/create {:multipart-params {:name "Test cab"
-                                           :licence_plate "KA20X1234"
-                                           :distance_travelled "1223"}}))))
+           (handlers/create {:multipart-params {:name "Test cab"
+                                                :licence_plate "KA20X1234"
+                                                :distance_travelled "1223"}}))))
 
   (testing "POST /cabs/ endpoint with invalid cab data, should redirect to '/cabs/new?error=true"
     (let [invalid-cab {:name "Test cab"
@@ -28,4 +31,18 @@
                       :data invalid-cab}
               :headers {"Location" "/cabs/new"}
               :body ""}
-             (cab/create {:multipart-params invalid-cab}))))))
+             (handlers/create {:multipart-params invalid-cab}))))))
+
+(deftest view-single-cab
+  (testing "Should return 200 code with the HTML of the single cab details view"
+    (let [cab (models/create {:name "Foo cab"
+                              :licence-plate "Foo Licence Plate"
+                              :distance-travelled 19191})
+          output-html (layout/application {}
+                                          (:cabs/name cab)
+                                          (views/single-cab cab))]
+      (is (= {:status 200
+              :body output-html}
+             (-> {:params {:slug (str (:cabs/id cab))}}
+                 handlers/view-cab
+                 (select-keys [:status :body])))))))

--- a/test/winter_onboarding_2021/fleet_management/handlers/cab_test.clj
+++ b/test/winter_onboarding_2021/fleet_management/handlers/cab_test.clj
@@ -1,5 +1,6 @@
 (ns winter-onboarding-2021.fleet-management.handlers.cab-test
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [clojure.string :as str]
             [winter-onboarding-2021.fleet-management-service.handlers.cab :as handlers]
             [winter-onboarding-2021.fleet-management-service.views.cab :as views]
             [winter-onboarding-2021.fleet-management-service.models.cab :as models]
@@ -10,28 +11,38 @@
 (use-fixtures :each fixtures/clear-db)
 
 (deftest add-cab
-  (testing "POST  /cabs/ endpoint with valid cab data, shoudld redirect to '/cabs/new?success=true' "
+  (testing "POST /cabs/ endpoint with valid cab data, shoudld redirect to '/cabs/<<uuid of new cab>> "
+    (let [response (handlers/create {:multipart-params
+                                     {:name "Test cab"
+                                      :licence_plate "KA20X1234"
+                                      :distance_travelled "1223"}})]
+      (is (= 302 (:status response)))
+
+      (is (= {:success true
+              :style-class "alert alert-success"
+              :message "Cab added successfully!"}
+             (:flash response)))
+
+      (is (= true (-> response
+                      (get-in [:headers "Location"])
+                      (str/split #"/") ; Could be better if we use regex
+                      (nth 2)
+                      count
+                      (= 36))))
+
+      (is (= "" (:body response))))))
+
+(testing "POST /cabs/ endpoint with invalid cab data, should redirect to '/cabs/new"
+  (let [invalid-cab {:name "Test cab"
+                     :licence_plate "KA20X1234"}]
     (is (= {:status 302
-            :flash {:success true
-                    :style-class "alert alert-success"
-                    :message "Cab added successfully!"}
+            :flash {:error true
+                    :style-class "alert alert-danger"
+                    :message "Could not add cab, try again!"
+                    :data invalid-cab}
             :headers {"Location" "/cabs/new"}
             :body ""}
-           (handlers/create {:multipart-params {:name "Test cab"
-                                                :licence_plate "KA20X1234"
-                                                :distance_travelled "1223"}}))))
-
-  (testing "POST /cabs/ endpoint with invalid cab data, should redirect to '/cabs/new?error=true"
-    (let [invalid-cab {:name "Test cab"
-                       :licence_plate "KA20X1234"}]
-      (is (= {:status 302
-              :flash {:error true
-                      :style-class "alert alert-danger"
-                      :message "Could not add cab, try again!"
-                      :data invalid-cab}
-              :headers {"Location" "/cabs/new"}
-              :body ""}
-             (handlers/create {:multipart-params invalid-cab}))))))
+           (handlers/create {:multipart-params invalid-cab})))))
 
 (deftest view-single-cab
   (testing "Should return 200 code with the HTML of the single cab details view"

--- a/test/winter_onboarding_2021/fleet_management/models/cab_test.clj
+++ b/test/winter_onboarding_2021/fleet_management/models/cab_test.clj
@@ -10,7 +10,7 @@
 (deftest create-cab
   (testing "Should add a cab"
     ;; NOTE: the cab/create input needs to be auto kebab'ised, need to use honeysql for this
-    (let [created-cab (cab/create {:licence_plate "HR20X 6710" 
+    (let [created-cab (cab/create {:licence_plate "HR20X 6710"
                                    :name "Maruti Celerio"
                                    :distance_travelled 2333})]
       (is (= #:cabs{:licence-plate "HR20X 6710"
@@ -26,3 +26,15 @@
          PSQLException
          #"null value in column \"licence_plate\" of relation \"cabs\""
          (cab/create {:name "Kia"})))))
+
+(deftest get-single-cab
+  (testing "Should get details of a single cab with a certain ID"
+    (let [cab (cab/create {:licence-plate "HR20X 9999"
+                           :name "Maruti Celerio 12"
+                           :distance-travelled 12221})]
+      (is (= cab
+             (cab/get-by-id (str (:cabs/id cab)))))))
+
+  (testing "Should return nil if there is no row with a id"
+    (is (= nil
+           (cab/get-by-id (str (java.util.UUID/randomUUID)))))))

--- a/test/winter_onboarding_2021/fleet_management/models/cab_test.clj
+++ b/test/winter_onboarding_2021/fleet_management/models/cab_test.clj
@@ -38,3 +38,13 @@
   (testing "Should return nil if there is no row with a id"
     (is (= nil
            (cab/get-by-id (str (java.util.UUID/randomUUID)))))))
+
+(deftest find-by-key
+  (testing "Should find a row with a specific licence-plate"
+    (let [sample-cab {:licence-plate "HR20X 9999"
+                      :name "Maruti Celerio 12"
+                      :distance-travelled 12221}
+          created-cab (cab/create sample-cab)
+          selected-cab (cab/find-by-keys (select-keys sample-cab [:distance-travelled]))]
+
+      (is (= created-cab (first selected-cab))))))

--- a/test/winter_onboarding_2021/fleet_management/views/cab_test.clj
+++ b/test/winter_onboarding_2021/fleet_management/views/cab_test.clj
@@ -39,7 +39,7 @@
           output-html (layout/application
                        {} ; request is empty
                        (format "Cab %s" (:name cab))
-                       (cab/single-cab cab))]
+                       (cab/cab cab))]
 
       (is (str/includes? output-html (:cabs/name cab)))
 

--- a/test/winter_onboarding_2021/fleet_management/views/cab_test.clj
+++ b/test/winter_onboarding_2021/fleet_management/views/cab_test.clj
@@ -30,3 +30,19 @@
       (is (str/includes?
            output-html
            (format "<div class=\"alert alert-danger\">%s</div>" error-msg))))))
+
+(deftest view-single-cab
+  (testing "Shold have the details like name, licence plate and distance travelled of single cab"
+    (let [cab #:cabs{:name "Maruti Cab"
+                     :licence-plate "HR20A 1234"
+                     :distance-travelled 12333}
+          output-html (layout/application
+                       {} ; request is empty
+                       (format "Cab %s" (:name cab))
+                       (cab/single-cab cab))]
+
+      (is (str/includes? output-html (:cabs/name cab)))
+
+      (is (str/includes? output-html (:cabs/licence-plate cab)))
+
+      (is (str/includes? output-html (str (:cabs/distance-travelled cab)))))))


### PR DESCRIPTION
Will show all the details of the cab captured when creating a cab.

Additionally, when the a cab is created, the web page will redirect to the show cab page, so that the user can verify the details.