### PR TITLE
Fix layout middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,14 @@ Steps:
 1. Clone this repo
 2. `cd` into the repo and run `lein deps`
 3. Run `lein test` to run the tests
+
+
+## What will handlers return?
+
+All handlers which render some HTML, should return a structure like below:
+```clojure
+{:title "Whatever Page title"
+ :content [:div "Whatever content of div"]}
+```
+
+Other endpoints can return a simple `ring.util.response/response` for returning something.

--- a/src/winter_onboarding_2021/fleet_management_service/handlers/cab.clj
+++ b/src/winter_onboarding_2021/fleet_management_service/handlers/cab.clj
@@ -35,7 +35,7 @@
 
 (defn view-cab [request]
   (let [cab (models/get-by-id (get-in request [:params :id]))]
-    {:title (:cabs/name cab)
+    {:title (str "Cab - "(:cabs/name cab))
      :content (views/cab cab)}))
 
 (defn get-cabs [req]

--- a/src/winter_onboarding_2021/fleet_management_service/handlers/cab.clj
+++ b/src/winter_onboarding_2021/fleet_management_service/handlers/cab.clj
@@ -29,12 +29,13 @@
                                (:cabs/id created-cab))))))))
 
 (defn new [request]
-  (views/cab-form
-   (get-in request [:flash :data])))
+  {:title "Add a cab"
+   :content (views/cab-form
+             (get-in request [:flash :data]))})
 
 (defn view-cab [request]
   (let [cab (models/get-by-id (get-in request [:params :id]))]
-    {:title (:name cab)
+    {:title (:cabs/name cab)
      :content (views/cab cab)}))
 
 (defn get-cabs [req]
@@ -46,6 +47,7 @@
                             page-size)
         rows-count (models/cabs-count)
         show-next-page? (<= (* current-page page-size) rows-count)]
-    (views/show-cabs cabs
-                     current-page
-                     show-next-page?)))
+    {:title "List cabs"
+     :content (views/show-cabs cabs
+                               current-page
+                               show-next-page?)}))

--- a/src/winter_onboarding_2021/fleet_management_service/routes.clj
+++ b/src/winter_onboarding_2021/fleet_management_service/routes.clj
@@ -9,14 +9,17 @@
 (defn wrap-layout [handler]
   (fn [request]
     (let [data (handler request)]
-      (response/response (layout/application request (:title data) (:content data))))))
+      (response/response (layout/application
+                          request
+                          (:title data)
+                          (:content data))))))
 
 (def routes
   ["/" [["public" {:get (br/->Resources {:prefix "/bootstrap"})}]
         ["cabs" {"" {:get (wrap-layout handlers/get-cabs)
                      :post handlers/create}
                  "/new" {:get (wrap-layout handlers/new)}
-                 [:id] {:get handlers/view-cab}}]
+                 ["/" :id] {:get (wrap-layout handlers/view-cab)}}]
         ["healthcheck" {:get (wrap-json-response handler/health-check)}]
         ["index" {:get (wrap-layout handler/index)}]
         [true (fn [_] {:status 404 :body "Not found"})]]])

--- a/src/winter_onboarding_2021/fleet_management_service/views/cab.clj
+++ b/src/winter_onboarding_2021/fleet_management_service/views/cab.clj
@@ -1,6 +1,5 @@
 (ns winter-onboarding-2021.fleet-management-service.views.cab
-  (:require [clojure.string :as string]
-            [camel-snake-kebab.core :as csk]))
+  (:require [camel-snake-kebab.core :as csk]))
 
 (defn labelled-text-input [label & args]
   (let [options (apply hash-map args)
@@ -44,27 +43,21 @@
     [:h3 (:cabs/distance-travelled cab)]]])
 
 (def headers
-  [:cabs/name
-   :cabs/distance-travelled
-   :cabs/licence-plate
-   :cabs/created-at
-   :cabs/updated-at])
-
-(defn format-header [namespaced-header]
-  (-> namespaced-header
-      name
-      (string/replace "-" " ")
-      string/capitalize))
+  [{:label "Name" :value :cabs/name}
+   {:label "Distance travelled" :value :cabs/distance-travelled}
+   {:label "Licence plate" :value :cabs/licence-plate}
+   {:label "Created at" :value :cabs/created-at}
+   {:label "Updated at" :value :cabs/updated-at}])
 
 (defn gen-cab-row [row]
   [:tr (map (fn [header] [:td (header row)])
-            headers)])
+            (map :value headers))])
 
 (defn show-cabs [cabs page-num show-next-page?]
   (let [next-page-query (str "?page=" (inc page-num))]
     [:div
      [:table {:class "table table-dark min-vh-40"}
-      [:thead [:tr (map (fn [header] [:th (format-header header)])
+      [:thead [:tr (map (fn [header] [:th (:label header)])
                         headers)]]
       [:tbody (map gen-cab-row cabs)]]
      [:div {:class "text-end"}

--- a/src/winter_onboarding_2021/fleet_management_service/views/cab.clj
+++ b/src/winter_onboarding_2021/fleet_management_service/views/cab.clj
@@ -1,9 +1,10 @@
 (ns winter-onboarding-2021.fleet-management-service.views.cab
-  (:require [camel-snake-kebab.core :as csk]))
+  (:require [clojure.string :as string]
+            [camel-snake-kebab.core :as csk]))
 
 (defn labelled-text-input [label & args]
   (let [options (apply hash-map args)
-        name (csk/->snake_case_string label)]
+        name (csk/->kebab-case-string label)]
     [:div
      [:label {:for label :class "form-label"} label]
      [:input (merge {:class "form-control" :type "text" :name name}
@@ -42,19 +43,30 @@
     [:div "Distance Travlled"]
     [:h3 (:cabs/distance-travelled cab)]]])
 
+(def headers
+  [:cabs/name
+   :cabs/distance-travelled
+   :cabs/licence-plate
+   :cabs/created-at
+   :cabs/updated-at])
+
+(defn format-header [namespaced-header]
+  (-> namespaced-header
+      name
+      (string/replace "-" " ")
+      string/capitalize))
+
+(defn gen-cab-row [row]
+  [:tr (map (fn [header] [:td (header row)])
+            headers)])
+
 (defn show-cabs [cabs page-num show-next-page?]
-  (let [head [:name :licence-plate :distance-travelled :created-at :updated-at]
-        next-page-query (str "?page=" (inc page-num))]
+  (let [next-page-query (str "?page=" (inc page-num))]
     [:div
      [:table {:class "table table-dark min-vh-40"}
-      [:thead [:tr
-               (map (fn [col] [:th (str col)])
-                    head)]]
-      [:tbody (map
-               (fn [row] [:tr (map
-                               (fn [cell] [:td (str cell)])
-                               row)])
-               cabs)]]
+      [:thead [:tr (map (fn [header] [:th (format-header header)])
+                        headers)]]
+      [:tbody (map gen-cab-row cabs)]]
      [:div {:class "text-end"}
       (if show-next-page?
         [:a {:id "cab-next-page" :href next-page-query}  "Next Page > "] ())]]))

--- a/test/winter_onboarding_2021/fleet_management/handlers/cab_test.clj
+++ b/test/winter_onboarding_2021/fleet_management/handlers/cab_test.clj
@@ -50,42 +50,42 @@
                               :licence-plate "Foo Licence Plate"
                               :distance-travelled 19191})
           content (views/cab cab)]
-      (is (= {:title (:name cab)
+      (is (= {:title (:cabs/name cab)
               :content content}
              (handlers/view-cab {:params {:id (str (:cabs/id cab))}}))))))
 
 (deftest list-cabs-handler
-  (testing "Should return a list of 3 rows of cabs"
-    (let [cabs (factories/create-cabs 3)]
-      (doall (map models/create cabs))
-      (with-redefs [config/get-page-size (constantly 2)]
-        (is (= 2 (count (hf/hiccup-find [:tbody :tr] (handlers/get-cabs {})))))
-        (is (not-empty (hf/hiccup-find [:#cab-next-page] (handlers/get-cabs {})))))))
+  (testing "Should return a list of 2 rows of cabs"
+    (with-redefs [config/get-page-size (constantly 2)]
+      (let [cabs (factories/create-cabs 3)
+            _ (doall (map models/create cabs))
+            output (handlers/get-cabs {})]
+        (is (= 2 (count (hf/hiccup-find [:tbody :tr] (:content output)))))
+        (is (not-empty (hf/hiccup-find [:#cab-next-page] (:content output)))))))
 
   (testing "Should return a list of 10 rows of cabs with next Page link"
-    (let [cabs (factories/create-cabs 12)]
-      (doall (map models/create cabs))
-      (is (= 10 (count (hf/hiccup-find [:tbody :tr] (handlers/get-cabs {})))))
-      (is (= 1 (count (hf/hiccup-find [:#cab-next-page] (handlers/get-cabs {})))))))
+      (let [cabs (factories/create-cabs 12)
+            _ (doall (map models/create cabs))
+            output (handlers/get-cabs {})]
+        (is (= 10 (count (hf/hiccup-find [:tbody :tr] (:content output)))))
+        (is (= 1 (count (hf/hiccup-find [:#cab-next-page] (:content output)))))))
 
-  (testing "Should return 8 rows of cabs in page number 2"
-    (is (= 5 (count (hf/hiccup-find [:tbody :tr]
-                                    (handlers/get-cabs
-                                     {:params
-                                      {:page "2"}})))))
-    (is (= 0 (count (hf/hiccup-find [:#cab-next-page]
-                                    (handlers/get-cabs
-                                     {:params
-                                      {:page "2"}}))))))
+  (testing "Should return 5 rows of cabs in page number 2"
+      (let [page-2-output (handlers/get-cabs {:params
+                                              {:page "2"}})]
+        (is (= 5 (count (hf/hiccup-find [:tbody :tr]
+                                        (:content page-2-output)))))
+        (is (= 0 (count (hf/hiccup-find [:#cab-next-page]
+                                        (:content page-2-output)))))))
 
   (testing "Should return 5 colums for :name :distance-travelled :licence-plate 
             :created-at :updated-at"
-    (let [cabs-list (handlers/get-cabs {})
-          hiccup-text (hf/hiccup-text cabs-list)]
-      (is (= 5 (count (hf/hiccup-find [:thead :tr :th]
-                                      cabs-list))))
-      (is (str/includes? hiccup-text "name"))
-      (is (str/includes? hiccup-text "distance-travelled"))
-      (is (str/includes? hiccup-text "licence-plate"))
-      (is (str/includes? hiccup-text "created-at"))
-      (is (str/includes? hiccup-text "updated-at")))))
+      (let [output (handlers/get-cabs {})
+            hiccup-text (hf/hiccup-text (:content output))]
+        (is (= 5 (count (hf/hiccup-find [:thead :tr :th]
+                                        (:content output)))))
+        (is (str/includes? hiccup-text "Name"))
+        (is (str/includes? hiccup-text "Distance travelled"))
+        (is (str/includes? hiccup-text "Licence plate"))
+        (is (str/includes? hiccup-text "Created at"))
+        (is (str/includes? hiccup-text "Updated at")))))

--- a/test/winter_onboarding_2021/fleet_management/handlers/cab_test.clj
+++ b/test/winter_onboarding_2021/fleet_management/handlers/cab_test.clj
@@ -50,7 +50,7 @@
                               :licence-plate "Foo Licence Plate"
                               :distance-travelled 19191})
           content (views/cab cab)]
-      (is (= {:title (:cabs/name cab)
+      (is (= {:title (str "Cab - "(:cabs/name cab))
               :content content}
              (handlers/view-cab {:params {:id (str (:cabs/id cab))}}))))))
 

--- a/test/winter_onboarding_2021/fleet_management/handlers/cab_test.clj
+++ b/test/winter_onboarding_2021/fleet_management/handlers/cab_test.clj
@@ -58,9 +58,20 @@
   (testing "Should return a list of 2 rows of cabs"
     (with-redefs [config/get-page-size (constantly 2)]
       (let [cabs (factories/create-cabs 3)
-            _ (doall (map models/create cabs))
+            db-cabs (doall (map models/create cabs))
             output (handlers/get-cabs {})]
         (is (= 2 (count (hf/hiccup-find [:tbody :tr] (:content output)))))
+        (is (= [[:tr [[:td (:cabs/name (first db-cabs))]
+                      [:td (:cabs/distance-travelled (first db-cabs))]
+                      [:td (:cabs/licence-plate (first db-cabs))]
+                      [:td (:cabs/created-at (first db-cabs))]
+                      [:td (:cabs/updated-at (first db-cabs))]]]
+                [:tr [[:td (:cabs/name (second db-cabs))]
+                      [:td (:cabs/distance-travelled (second db-cabs))]
+                      [:td (:cabs/licence-plate (second db-cabs))]
+                      [:td (:cabs/created-at (second db-cabs))]
+                      [:td (:cabs/updated-at (second db-cabs))]]]]
+               (hf/hiccup-find [:tbody :tr] (:content output))))
         (is (not-empty (hf/hiccup-find [:#cab-next-page] (:content output)))))))
 
   (testing "Should return a list of 10 rows of cabs with next Page link"

--- a/test/winter_onboarding_2021/fleet_management/views/cab_test.clj
+++ b/test/winter_onboarding_2021/fleet_management/views/cab_test.clj
@@ -4,6 +4,11 @@
             [winter-onboarding-2021.fleet-management-service.views.cab :as cab]
             [winter-onboarding-2021.fleet-management-service.views.layout :as layout]))
 
+(deftest header-formatting
+  (testing "Should convert a namespaced keyword into human string"
+    (is (= "Distance travelled"
+           (cab/format-header :cabs/distance-travelled)))))
+
 (deftest add-cab-view
   (testing "Should have alert success bubble after adding a valid cab"
     (let [success-msg "Cab added successfully!"

--- a/test/winter_onboarding_2021/fleet_management/views/cab_test.clj
+++ b/test/winter_onboarding_2021/fleet_management/views/cab_test.clj
@@ -4,11 +4,6 @@
             [winter-onboarding-2021.fleet-management-service.views.cab :as cab]
             [winter-onboarding-2021.fleet-management-service.views.layout :as layout]))
 
-(deftest header-formatting
-  (testing "Should convert a namespaced keyword into human string"
-    (is (= "Distance travelled"
-           (cab/format-header :cabs/distance-travelled)))))
-
 (deftest add-cab-view
   (testing "Should have alert success bubble after adding a valid cab"
     (let [success-msg "Cab added successfully!"


### PR DESCRIPTION
When we extracted the `layout/application` to work as a middleware, we didn't write the middleware in such a way that it could handle dynamic page titles(in view single cab details handler).

When we modified the `wrap-layout` to accomodate dynamic page titles, we failed to change the other handlers to return title and as a result, tests passed but the staging server didn't work as expected.

This PR fixes all of that. Now, we can return dynamic titles from any handler.
The tests are also modified to expect new structure returned from a handler.

All **handlers** which are user facing, will now give us data in this form:

```clojure
{:title "Whatever Page title"
 :content [:div "Whatever content of div"]}
```