### PR TITLE
Lookup cab by licence no

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -69,6 +69,9 @@ jobs:
 
     - name: Run migrations
       run: lein migrations migrate
+    
+    - name: Run Licence Plate data migration
+      run: lein migrate-licence-plate
 
     - name: Run tests
       run: lein cloverage

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -69,9 +69,6 @@ jobs:
 
     - name: Run migrations
       run: lein migrations migrate
-    
-    - name: Run Licence Plate data migration
-      run: lein migrate-licence-plate
 
     - name: Run tests
       run: lein cloverage

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ pom.xml.asc
 *.tfvars
 .terraform/
 .terraform.*
+.DS_Store

--- a/project.clj
+++ b/project.clj
@@ -17,10 +17,11 @@
                  [org.clojure/spec.alpha "0.3.214"]
                  [migratus "1.3.5"]
                  [camel-snake-kebab "0.4.2"]
-                 [com.github.seancorfield/honeysql "2.1.833"]
                  [com.taoensso/timbre "5.1.0"]
-                 [io.aviso/pretty "1.1"]]
-  :aliases {"migrations" ["run" "-m" "winter-onboarding-2021.fleet-management-service.migration/run-migratus"]}
+                 [io.aviso/pretty "1.1"]
+                 [com.github.seancorfield/honeysql "2.1.833"]]
+  :aliases {"migrations" ["run" "-m" "winter-onboarding-2021.fleet-management-service.migration/run-migratus"]
+            "migrate-licence-plate" ["run" "-m" "format-licence-plate/run-data-migration"]}
   :profiles {:uberjar {:aot :all}
              :test {:cloverage {:fail-threshold 70
                                 :ns-exclude-regex [#"user"]}}
@@ -30,6 +31,7 @@
   :plugins [[lein-cloverage "1.2.2"]]
   :repl-options {:init-ns user}
   :resource-paths ["config" "resources"]
+  :source-paths ["src" "scripts"]
   :uberjar-name "winter-onboarding-2021-standalone.jar"
   :main winter-onboarding-2021.fleet-management-service.core
   :min-lein-version "2.0.0")

--- a/resources/migrations/20211213061358-remove-spaces-licence-plate.up.sql
+++ b/resources/migrations/20211213061358-remove-spaces-licence-plate.up.sql
@@ -1,4 +1,0 @@
-UPDATE
-  cabs
-SET
-  licence_plate = regexp_replace(licence_plate, '[^a-zA-Z\d:]', '', 'g');

--- a/resources/migrations/20211213061358-remove-spaces-licence-plate.up.sql
+++ b/resources/migrations/20211213061358-remove-spaces-licence-plate.up.sql
@@ -1,0 +1,4 @@
+UPDATE
+  cabs
+SET
+  licence_plate = regexp_replace(licence_plate, '[^a-zA-Z\d:]', '', 'g');

--- a/scripts/format_licence_plate.clj
+++ b/scripts/format_licence_plate.clj
@@ -1,0 +1,37 @@
+(ns format-licence-plate
+  (:require [mount.core :as mount]
+            [honey.sql :as h-sql]
+            [next.jdbc :as jdbc]
+            [next.jdbc.sql :as sql]
+            [honey.sql.helpers :as h]
+            [clojure.spec.alpha :as s]
+            [clojure.string :as string]
+            [winter-onboarding-2021.fleet-management-service.specs]
+            [winter-onboarding-2021.fleet-management-service.db.core :as db-core]))
+
+(defn process-cab
+  "Will recieve a Cab hashmap & will return [cab-id new-licence-plate]
+   where `new-licence-plate` only contains alphanumeric characters"
+  [cab]
+  (let [licence-plate (:cabs/licence-plate cab)]
+    (when (s/invalid? (s/conform :cabs/licence-plate licence-plate))
+      [(string/replace licence-plate #"[^a-zA-Z0-9]" "")
+       (:cabs/id cab)])))
+
+(defn run-data-migration []
+  (try (mount/start)
+       (let [cabs (sql/query db-core/db-conn
+                             (h-sql/format (-> (h/select :name
+                                                         :id
+                                                         :licence_plate)
+                                               (h/from :cabs)))
+                             db-core/sql-opts)
+             to-be-updated-cabs (remove nil? (map process-cab cabs))]
+         (jdbc/execute-batch! db-core/db-conn
+                              "UPDATE cabs SET licence_plate = ? WHERE id = ?"
+                              to-be-updated-cabs
+                              {})
+         (println "Data migrated successfully"))
+       (catch Exception e
+         (println "Some error occured while migrating data")
+         (println (.getMessage e)))))

--- a/src/winter_onboarding_2021/fleet_management_service/db/cab.clj
+++ b/src/winter_onboarding_2021/fleet_management_service/db/cab.clj
@@ -34,5 +34,11 @@
   (db/query! (sql/format (-> (update :cabs)
                              (set cab)
                              (where [:= :id id])))))
+
 (defn delete [where-params]
   (db/delete! :cabs where-params))
+
+(defn get-by-id-or-licence-plate [id licence-plate]
+  (first (db/query! (sql/format (-> (select :*)
+                                    (from :cabs)
+                                    (where :or [:= :id id] [:= :licence-plate licence-plate]))))))

--- a/src/winter_onboarding_2021/fleet_management_service/handlers/cab.clj
+++ b/src/winter_onboarding_2021/fleet_management_service/handlers/cab.clj
@@ -62,7 +62,9 @@
              (get-in request [:flash :data]))})
 
 (defn view-cab [{:keys [params]}]
-  (view-cab-response (models/get-by-id-or-licence-plate (:slug params))))
+  (if-let [slug (:slug params)]
+    (view-cab-response (models/get-by-id-or-licence-plate slug))
+    (response/redirect "/cabs")))
 
 (defn get-cabs [req]
   (let [{:keys [page]} (:params req)
@@ -91,9 +93,8 @@
         (merge update-success-flash
                (response/redirect (format "/cabs/%s" id)))))))
 
-(defn update-cab-view [req]
-  (let [cab (models/get-by-id (utils/string->uuid
-                               (get-in req [:params :slug])))]
+(defn update-cab-view [{:keys [params]}]
+  (let [cab (models/get-by-id-or-licence-plate (:slug params))]
     {:title (str "Update cab " (:cabs/licence-plate cab))
      :content (views/update-cab-form cab)}))
 

--- a/src/winter_onboarding_2021/fleet_management_service/handlers/cab.clj
+++ b/src/winter_onboarding_2021/fleet_management_service/handlers/cab.clj
@@ -66,7 +66,7 @@
              (get-in request [:flash :data]))})
 
 (defn view-cab [request]
-  (let [id-or-licence (get-in request [:params :id])]
+  (let [id-or-licence (get-in request [:params :slug])]
     (if-let [id (string->uuid id-or-licence)]
       (view-cab-response (models/get-by-id id))
       (view-cab-response (models/get-by-licence-plate id-or-licence)))))
@@ -84,9 +84,10 @@
      :content (views/show-cabs cabs
                                current-page
                                show-next-page?)}))
+
 (defn update-cab [req]
   (let [cab (:multipart-params req)
-        id (get-in req [:params :id])
+        id (get-in req [:params :slug])
         validated-cab (s/conform ::specs/update-cab-form cab)]
     (if (s/invalid? validated-cab)
       (-> update-error-flash
@@ -99,7 +100,7 @@
 
 (defn update-cab-view [req]
   (let [cab (models/get-by-id (string->uuid (get-in req 
-                                                    [:params :id])))]
+                                                    [:params :slug])))]
     {:title (str "Update cab " (:cabs/licence-plate cab))
      :content (views/update-cab-form cab)}))
 

--- a/src/winter_onboarding_2021/fleet_management_service/models/cab.clj
+++ b/src/winter_onboarding_2021/fleet_management_service/models/cab.clj
@@ -29,7 +29,7 @@
 (defn get-by-licence-plate [licence-no]
   (first (cab-db/find-by-keys {:licence-plate licence-no})))
 
-(defn get-by-id-or-licence-plate [id-or-licence-no]
-  (if-let [id (utils/string->uuid id-or-licence-no)]
-    (get-by-id id)
-    (get-by-licence-plate id-or-licence-no)))
+(defn get-by-id-or-licence-plate [val]
+  (let [id (utils/string->uuid val)
+        licence-plate val]
+    (cab-db/get-by-id-or-licence-plate id licence-plate)))

--- a/src/winter_onboarding_2021/fleet_management_service/models/cab.clj
+++ b/src/winter_onboarding_2021/fleet_management_service/models/cab.clj
@@ -24,3 +24,6 @@
 (defn delete-by-id [id]
   {:pre [(string? id)]}
   (cab-db/delete {:id (java.util.UUID/fromString id)}))
+
+(defn get-by-licence-plate [licence-no]
+  (cab-db/find-by-keys {:licence-plate licence-no}))

--- a/src/winter_onboarding_2021/fleet_management_service/models/cab.clj
+++ b/src/winter_onboarding_2021/fleet_management_service/models/cab.clj
@@ -3,7 +3,7 @@
             [winter-onboarding-2021.fleet-management-service.config :as config]))
 
 (defn get-by-id [id]
-  (cab-db/get-by-id (java.util.UUID/fromString id)))
+  (cab-db/get-by-id id))
 
 (defn find-by-keys [key-map]
   (cab-db/find-by-keys key-map))
@@ -19,11 +19,11 @@
   (:count (first (cab-db/get-count))))
 
 (defn update! [id cab]
-  (cab-db/update! (java.util.UUID/fromString id) cab))
+  (cab-db/update! id cab))
 
 (defn delete-by-id [id]
   {:pre [(string? id)]}
   (cab-db/delete {:id (java.util.UUID/fromString id)}))
 
 (defn get-by-licence-plate [licence-no]
-  (cab-db/find-by-keys {:licence-plate licence-no}))
+  (first (cab-db/find-by-keys {:licence-plate licence-no})))

--- a/src/winter_onboarding_2021/fleet_management_service/models/cab.clj
+++ b/src/winter_onboarding_2021/fleet_management_service/models/cab.clj
@@ -1,6 +1,7 @@
 (ns winter-onboarding-2021.fleet-management-service.models.cab
   (:require [winter-onboarding-2021.fleet-management-service.db.cab :as cab-db]
-            [winter-onboarding-2021.fleet-management-service.config :as config]))
+            [winter-onboarding-2021.fleet-management-service.config :as config]
+            [winter-onboarding-2021.fleet-management-service.utils :as utils]))
 
 (defn get-by-id [id]
   (cab-db/get-by-id id))
@@ -27,3 +28,8 @@
 
 (defn get-by-licence-plate [licence-no]
   (first (cab-db/find-by-keys {:licence-plate licence-no})))
+
+(defn get-by-id-or-licence-plate [id-or-licence-no]
+  (if-let [id (utils/string->uuid id-or-licence-no)]
+    (get-by-id id)
+    (get-by-licence-plate id-or-licence-no)))

--- a/src/winter_onboarding_2021/fleet_management_service/routes.clj
+++ b/src/winter_onboarding_2021/fleet_management_service/routes.clj
@@ -21,9 +21,9 @@
                      :post handlers/create}
                  "/new" {:get (wrap-layout handlers/new)}
                  "/delete" {:post handlers/delete}
-                 ["/" :id] {:get (wrap-layout handlers/view-cab)
-                            :post handlers/update-cab
-                            "/edit" {:get (wrap-layout handlers/update-cab-view)}}}]
+                 ["/" :slug] {"/edit" {:get (wrap-layout handlers/update-cab-view)}
+                              :get (wrap-layout handlers/view-cab)
+                              :post handlers/update-cab}}]
         ["healthcheck" {:get (wrap-json-response handler/health-check)}]
         ["index" {:get (wrap-layout handler/index)}]
         ["" {:get (wrap-layout handler/root)}]

--- a/src/winter_onboarding_2021/fleet_management_service/specs.clj
+++ b/src/winter_onboarding_2021/fleet_management_service/specs.clj
@@ -1,14 +1,15 @@
 (ns winter-onboarding-2021.fleet-management-service.specs
   (:require [clojure.spec.alpha :as s]))
 
+(def licence-plate-regex #"^[a-zA-Z0-9]*$")
+
 (s/def :cabs/name string?)
-(s/def :cabs/licence-plate (s/and string? not-empty))
+(s/def :cabs/licence-plate (s/and string? not-empty #(re-matches licence-plate-regex %)))
 (s/def :cabs/distance-travelled (s/int-in 0 100000000000))
 (s/def :cabs-form/distance-travelled (s/conformer
                                       #(try (Long/parseLong %)
                                             (catch Exception _ :clojure.spec.alpha/invalid))
                                       str))
-
 
 (s/def ::create-cab-form
   (s/keys :req-un [:cabs/name

--- a/src/winter_onboarding_2021/fleet_management_service/utils.clj
+++ b/src/winter_onboarding_2021/fleet_management_service/utils.clj
@@ -1,0 +1,5 @@
+(ns winter-onboarding-2021.fleet-management-service.utils)
+
+(defn string->uuid [id]
+  (try (java.util.UUID/fromString id)
+       (catch Exception _ nil)))

--- a/src/winter_onboarding_2021/fleet_management_service/views/cab.clj
+++ b/src/winter_onboarding_2021/fleet_management_service/views/cab.clj
@@ -96,6 +96,10 @@
    [:td (format-date (:cabs/updated-at row))]
    [:td (format-date (:cabs/created-at row))]])
 
+(defn cab-not-found []
+  [:div {:id "content" :class "p-5"}
+   [:h2 "No cabs found"]])
+
 (defn show-cabs [cabs page-num show-next-page?]
   (let [next-page-query (str "?page=" (inc page-num))]
     [:div

--- a/src/winter_onboarding_2021/fleet_management_service/views/cab.clj
+++ b/src/winter_onboarding_2021/fleet_management_service/views/cab.clj
@@ -18,17 +18,21 @@
       "Cab Name"
       :name "name"
       :required true
+      :placeholder "Enter cab name"
       :value name)]
     [:div {:class "mb-3"}
      (labelled-text-input
       "Licence Plate"
       :required true
+      :placeholder "Enter licence plate (only alphabets and number allowed)"
+      :pattern "^[a-zA-Z0-9]*$"
       :value licence-plate)]
     [:div {:class "mb-3"}
      (labelled-text-input
       "Distance Travelled"
       :type "number"
       :required true
+      :placeholder "Enter distance in meters"
       :value distance-travelled)]
     [:button {:type "submit" :class "btn btn-primary"} "Submit"]]])
 
@@ -120,6 +124,7 @@
        [:div {:class "mb-3"}
         (labelled-text-input
          "Cab Name"
+         :placeholder "Enter cab name"
          :name "name"
          :required true
          :value name)]
@@ -127,12 +132,15 @@
         (labelled-text-input
          "Licence Plate"
          :required true
+         :placeholder "Enter licence plate (only alphabets and number allowed)"
+         :pattern "^[a-zA-Z0-9]*$"
          :disabled true
          :value licence-plate)]
        [:div {:class "mb-3"}
         (labelled-text-input
          "Distance Travelled"
          :type "number"
+         :placeholder "Enter distance in meters"
          :required true
          :value distance-travelled)]
        [:button {:type "submit" :class "btn btn-success"} "Update"]]]]))

--- a/test/winter_onboarding_2021/fleet_management/db/cab_test.clj
+++ b/test/winter_onboarding_2021/fleet_management/db/cab_test.clj
@@ -63,7 +63,6 @@
       (cab-db/delete {:id (:cabs/id db-cab)})
       (is (= nil (-> db-cab
                      :cabs/id
-                     str
                      models/get-by-id)))))
   (testing "Should return 0 when a cab with a specific ID is not found for deletion"
     (let [cab-id (java.util.UUID/randomUUID)

--- a/test/winter_onboarding_2021/fleet_management/db/cab_test.clj
+++ b/test/winter_onboarding_2021/fleet_management/db/cab_test.clj
@@ -68,3 +68,24 @@
     (let [cab-id (java.util.UUID/randomUUID)
           output (cab-db/delete {:id cab-id})]
       (is (= 0 (:next.jdbc/update-count output))))))
+
+(deftest get-by-id-or-licence-plate
+  (testing "Should return a cab, given a licence plate"
+    (let [cab {:name "Maruti"
+             :licence-plate "MHOR1234"
+             :distance-travelled 123340}
+        inserted-cab (cab-db/create cab)
+        cab-by-licence (cab-db/get-by-id-or-licence-plate nil (:licence-plate cab))]
+    (is (= cab-by-licence inserted-cab))))
+  (testing "Should return a cab, given an id"
+    (let [cab {:name "Maruti"
+               :licence-plate "MHOR1233"
+               :distance-travelled 123340}
+          inserted-cab (cab-db/create cab)
+          id (:cabs/id inserted-cab)
+          cab-by-id (cab-db/get-by-id-or-licence-plate id (str id))]
+      (is (= cab-by-id inserted-cab))))
+  (testing "Should return nil, given a non-exsistent id or licence"
+    (let [id (java.util.UUID/randomUUID)
+          cab-by-id (cab-db/get-by-id-or-licence-plate id (str id))]
+      (is (= nil cab-by-id)))))

--- a/test/winter_onboarding_2021/fleet_management/handlers/cab_test.clj
+++ b/test/winter_onboarding_2021/fleet_management/handlers/cab_test.clj
@@ -53,13 +53,13 @@
           content (views/cab cab)]
       (is (= {:title (str "Cab - " (:cabs/name cab))
               :content content}
-             (handlers/view-cab {:params {:id (str (:cabs/id cab))}})))
+             (handlers/view-cab {:params {:slug (str (:cabs/id cab))}})))
       (is (= {:title (str "Cab - " (:cabs/name cab))
               :content content}
-             (handlers/view-cab {:params {:id (str (:cabs/licence-plate cab))}})))
+             (handlers/view-cab {:params {:slug (str (:cabs/licence-plate cab))}})))
       (is (= {:title "No cabs found"
               :content (views/cab-not-found)}
-             (handlers/view-cab {:params {:id (str (java.util.UUID/randomUUID))}}))))))
+             (handlers/view-cab {:params {:slug (str (java.util.UUID/randomUUID))}}))))))
 
 (deftest list-cabs-handler
   (testing "Should return a list of 2 rows of cabs"
@@ -70,10 +70,10 @@
             second-cab (second db-cabs)
             output (:content (handlers/get-cabs {}))
             html-output (hp/html5 output)]
-        
+
         (is (= 2 (count (hf/hiccup-find [:tbody :tr] output))))
         (is (= 2 (count (hf/hiccup-find [:tr :td :a] output))))
-        
+
         (is (str/includes? html-output (:cabs/name first-cab)))
         (is (str/includes? html-output (str (:cabs/distance-travelled first-cab))))
         (is (str/includes? html-output (:cabs/licence-plate first-cab)))
@@ -116,7 +116,7 @@
       (is (str/includes? hiccup-text "Updated at")))))
 
 (deftest update-cab
-  (testing "Should redirect to /cabs:id with success flash
+  (testing "Should redirect to /cabs:slug with success flash
             after successfull update of cab with given id and cab data"
     (let [cab {:name "Maruti Cab"
                :licence-plate "HR20A 1234"
@@ -124,7 +124,7 @@
           cab-id (str (:cabs/id (models/create cab)))
           new-cab {:name "Maruti Cab"
                    :distance-travelled "13000"}
-          response (handlers/update-cab {:params {:id cab-id}
+          response (handlers/update-cab {:params {:slug cab-id}
                                          :multipart-params new-cab})]
       (is (= 302 (response :status)))
       (is (= {:success true
@@ -141,7 +141,7 @@
     (let [cab-id (:cabs/id (models/create {:name "Some name"
                                            :licence-plate "License plate"
                                            :distance-travelled 123}))
-          response (handlers/update-cab {:params {:id (str cab-id)}
+          response (handlers/update-cab {:params {:slug (str cab-id)}
                                          :multipart-params {:foo "boo"}})]
       (is (= 302 (:status response)))
       (is (= true (get-in response [:flash :error])))
@@ -159,7 +159,7 @@
           cab-id (:cabs/id (models/create cab))]
       (is (= "Update cab KA20X1234"
              (:title (handlers/update-cab-view {:params
-                                                {:id (str cab-id)}})))))))
+                                                {:slug (str cab-id)}})))))))
 
 (deftest deletion
   (testing "Should redirect to cabs' list when delete succeeds"
@@ -176,6 +176,7 @@
               :headers {"Location" "/cabs"}
               :body ""}
              handler-resp))))
+  
   (testing "Should redirect to /cabs when delete fails"
     (let [missing-uuid (str (java.util.UUID/randomUUID))
           handler-response (handlers/delete {:params {:id missing-uuid}})]

--- a/test/winter_onboarding_2021/fleet_management/handlers/cab_test.clj
+++ b/test/winter_onboarding_2021/fleet_management/handlers/cab_test.clj
@@ -8,7 +8,8 @@
             [winter-onboarding-2021.fleet-management-service.config :as config]
             [winter-onboarding-2021.fleet-management-service.models.cab :as models]
             [winter-onboarding-2021.fleet-management-service.views.cab :as views]
-            [winter-onboarding-2021.fleet-management-service.handlers.cab :as handlers]))
+            [winter-onboarding-2021.fleet-management-service.handlers.cab :as handlers]
+            [winter-onboarding-2021.fleet-management-service.utils :as utils]))
 
 (use-fixtures :once fixtures/config fixtures/db-connection)
 (use-fixtures :each fixtures/clear-db)
@@ -134,7 +135,7 @@
              (get-in response [:headers "Location"])))
       (is (= {:cabs/name "Maruti Cab"
               :cabs/distance-travelled 13000}
-             (select-keys (models/get-by-id (handlers/string->uuid cab-id))
+             (select-keys (models/get-by-id (utils/string->uuid cab-id))
                           [:cabs/name :cabs/distance-travelled])))))
 
   (testing "Should redirect with an error message when update fails"

--- a/test/winter_onboarding_2021/fleet_management/handlers/cab_test.clj
+++ b/test/winter_onboarding_2021/fleet_management/handlers/cab_test.clj
@@ -48,12 +48,18 @@
 (deftest view-single-cab
   (testing "Should return 200 code with the HTML of the single cab details view"
     (let [cab (models/create {:name "Foo cab"
-                              :licence-plate "Foo Licence Plate"
+                              :licence-plate "FooLicencePlate"
                               :distance-travelled 19191})
           content (views/cab cab)]
       (is (= {:title (str "Cab - " (:cabs/name cab))
               :content content}
-             (handlers/view-cab {:params {:id (str (:cabs/id cab))}}))))))
+             (handlers/view-cab {:params {:id (str (:cabs/id cab))}})))
+      (is (= {:title (str "Cab - " (:cabs/name cab))
+              :content content}
+             (handlers/view-cab {:params {:id (str (:cabs/licence-plate cab))}})))
+      (is (= {:title "No cabs found"
+              :content (views/cab-not-found)}
+             (handlers/view-cab {:params {:id (str (java.util.UUID/randomUUID))}}))))))
 
 (deftest list-cabs-handler
   (testing "Should return a list of 2 rows of cabs"
@@ -128,7 +134,7 @@
              (get-in response [:headers "Location"])))
       (is (= {:cabs/name "Maruti Cab"
               :cabs/distance-travelled 13000}
-             (select-keys (models/get-by-id cab-id)
+             (select-keys (models/get-by-id (handlers/string->uuid cab-id))
                           [:cabs/name :cabs/distance-travelled])))))
 
   (testing "Should redirect with an error message when update fails"
@@ -142,7 +148,7 @@
       (is (re-find #"(?i)could not update" (get-in response [:flash :message])))
       (is (= {:cabs/name "Some name"
               :cabs/distance-travelled 123}
-             (select-keys (models/get-by-id (str cab-id))
+             (select-keys (models/get-by-id cab-id)
                           [:cabs/name :cabs/distance-travelled]))))))
 
 (deftest update-cab-form

--- a/test/winter_onboarding_2021/fleet_management/models/cab_test.clj
+++ b/test/winter_onboarding_2021/fleet_management/models/cab_test.clj
@@ -87,3 +87,36 @@
                                                  cab-by-licence
                                                  [:cabs/id :cabs/name :cabs/licence-plate :cabs/distance-travelled])))
       (is (= cab-id (:cabs/id cab-by-licence))))))
+
+(deftest get-cab-by-licence-plate-or-id
+  (testing "Should return a cab given a licence plate"
+    (let [cab {:name "Maruti"
+               :licence-plate "ODAH12342"
+               :distance-travelled 123445}
+          cab-id (:cabs/id (cab-model/create cab))
+          cab-by-licence (cab-model/get-by-id-or-licence-plate (:licence-plate cab))]
+      (is (= #:cabs{:id cab-id
+                    :name "Maruti"
+                    :licence-plate "ODAH12342"
+                    :distance-travelled 123445}
+             (select-keys cab-by-licence
+                          [:cabs/id :cabs/name :cabs/licence-plate :cabs/distance-travelled])))
+      (is (= cab-id (:cabs/id cab-by-licence)))))
+
+  (testing "Should return a cab given a cab UUID"
+    (let [cab {:name "Maruti"
+               :licence-plate "ODAH1234"
+               :distance-travelled 123445}
+          cab-id (:cabs/id (cab-model/create cab))
+          cab-by-licence (cab-model/get-by-id-or-licence-plate (str cab-id))]
+      (is (= #:cabs{:id cab-id
+                    :name "Maruti"
+                    :licence-plate "ODAH1234"
+                    :distance-travelled 123445}
+             (select-keys cab-by-licence
+                          [:cabs/id :cabs/name :cabs/licence-plate :cabs/distance-travelled])))
+      (is (= cab-id (:cabs/id cab-by-licence)))))
+
+  (testing "Should return nil if cab doesnt exist with a certain licence plate or UUID"
+    (let [cab-by-licence (cab-model/get-by-id-or-licence-plate (str (java.util.UUID/randomUUID)))]
+      (is (= nil cab-by-licence)))))

--- a/test/winter_onboarding_2021/fleet_management/models/cab_test.clj
+++ b/test/winter_onboarding_2021/fleet_management/models/cab_test.clj
@@ -71,7 +71,6 @@
       (cab-model/delete-by-id (str (:cabs/id db-cab)))
       (is (= nil (-> db-cab
                      :cabs/id
-                     str
                      cab-model/get-by-id))))))
 
 (deftest get-cab-by-licence-plate

--- a/test/winter_onboarding_2021/fleet_management/models/cab_test.clj
+++ b/test/winter_onboarding_2021/fleet_management/models/cab_test.clj
@@ -33,11 +33,11 @@
                                  :name "Maruti Celerio 12"
                                  :distance-travelled 12221})]
       (is (= cab
-             (cab-model/get-by-id (str (:cabs/id cab)))))))
+             (cab-model/get-by-id (:cabs/id cab))))))
 
   (testing "Should return nil if there is no row with a id"
     (is (= nil
-           (cab-model/get-by-id (str (java.util.UUID/randomUUID)))))))
+           (cab-model/get-by-id (java.util.UUID/randomUUID))))))
 
 (deftest find-by-key
   (testing "Should find a row with a specific licence-plate"
@@ -55,7 +55,7 @@
                :licence-plate "MHOR1234"
                :distance-travelled 123340}
           inserted-cab (cab-model/create cab)
-          id (str (inserted-cab :cabs/id))
+          id (:cabs/id inserted-cab)
           new-cab {:name "Maruti"
                    :licence-plate "MHOR1234"
                    :distance-travelled 123500}]
@@ -80,7 +80,7 @@
                :licence-plate "ODAH1234"
                :distance-travelled 123445}
           cab-id (:cabs/id (cab-model/create cab))
-          cab-by-licence (first (cab-model/get-by-licence-plate (:licence-plate cab)))]
+          cab-by-licence (cab-model/get-by-licence-plate (:licence-plate cab))]
       (is (= #:cabs{:id cab-id
                     :name "Maruti"
                     :licence-plate "ODAH1234"

--- a/test/winter_onboarding_2021/fleet_management/models/cab_test.clj
+++ b/test/winter_onboarding_2021/fleet_management/models/cab_test.clj
@@ -89,21 +89,21 @@
       (is (= cab-id (:cabs/id cab-by-licence))))))
 
 (deftest get-cab-by-licence-plate-or-id
-  (testing "Should return a cab given a licence plate"
+  (testing "Should return a cab given a licence plate number or an id"
     (let [cab {:name "Maruti"
                :licence-plate "ODAH12342"
                :distance-travelled 123445}
           cab-id (:cabs/id (cab-model/create cab))
-          cab-by-licence (cab-model/get-by-id-or-licence-plate (:licence-plate cab))]
+          cab-by-licence-or-id (cab-model/get-by-id-or-licence-plate (:licence-plate cab))]
       (is (= #:cabs{:id cab-id
                     :name "Maruti"
                     :licence-plate "ODAH12342"
                     :distance-travelled 123445}
-             (select-keys cab-by-licence
+             (select-keys cab-by-licence-or-id
                           [:cabs/id :cabs/name :cabs/licence-plate :cabs/distance-travelled])))
-      (is (= cab-id (:cabs/id cab-by-licence)))))
+      (is (= cab-id (:cabs/id cab-by-licence-or-id)))))
 
-  (testing "Should return a cab given a cab UUID"
+  (testing "Should return a cab given a cab id"
     (let [cab {:name "Maruti"
                :licence-plate "ODAH1234"
                :distance-travelled 123445}

--- a/test/winter_onboarding_2021/fleet_management/models/cab_test.clj
+++ b/test/winter_onboarding_2021/fleet_management/models/cab_test.clj
@@ -11,8 +11,8 @@
   (testing "Should add a cab"
     ;; NOTE: the cab/create input needs to be auto kebab'ised, need to use honeysql for this
     (let [created-cab (cab-model/create {:licence_plate "HR20X 6710"
-                                   :name "Maruti Celerio"
-                                   :distance_travelled 2333})]
+                                         :name "Maruti Celerio"
+                                         :distance_travelled 2333})]
       (is (= #:cabs{:licence-plate "HR20X 6710"
                     :name "Maruti Celerio"
                     :distance-travelled 2333}
@@ -30,8 +30,8 @@
 (deftest get-single-cab
   (testing "Should get details of a single cab with a certain ID"
     (let [cab (cab-model/create {:licence-plate "HR20X 9999"
-                           :name "Maruti Celerio 12"
-                           :distance-travelled 12221})]
+                                 :name "Maruti Celerio 12"
+                                 :distance-travelled 12221})]
       (is (= cab
              (cab-model/get-by-id (str (:cabs/id cab)))))))
 
@@ -73,3 +73,18 @@
                      :cabs/id
                      str
                      cab-model/get-by-id))))))
+
+(deftest get-cab-by-licence-plate
+  (testing "Should return a cab given a licence plate"
+    (let [cab {:name "Maruti"
+               :licence-plate "ODAH1234"
+               :distance-travelled 123445}
+          cab-id (:cabs/id (cab-model/create cab))
+          cab-by-licence (first (cab-model/get-by-licence-plate (:licence-plate cab)))]
+      (is (= #:cabs{:id cab-id
+                    :name "Maruti"
+                    :licence-plate "ODAH1234"
+                    :distance-travelled 123445} (select-keys
+                                                 cab-by-licence
+                                                 [:cabs/id :cabs/name :cabs/licence-plate :cabs/distance-travelled])))
+      (is (= cab-id (:cabs/id cab-by-licence))))))


### PR DESCRIPTION
Now, we can view a cab's details via looking up its licence plate or the UUID.
Just put the licence plate or the UUID after `/cabs/`.

For example, with UUID:
`/cabs/5fcc2591-ec24-4833-be44-7e0adcacd4ff`


For example, with Licence Plate:
`/cabs/testplatenumber`
