### PR TITLE
Create fleet

### DIFF
--- a/resources/migrations/20211220103859-create-fleet.down.sql
+++ b/resources/migrations/20211220103859-create-fleet.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS fleets;

--- a/resources/migrations/20211220103859-create-fleet.up.sql
+++ b/resources/migrations/20211220103859-create-fleet.up.sql
@@ -1,0 +1,6 @@
+CREATE TABLE fleets(
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    name TEXT NOT NULL,
+    created_by UUID REFERENCES users(id) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);

--- a/src/winter_onboarding_2021/fleet_management_service/db/fleet.clj
+++ b/src/winter_onboarding_2021/fleet_management_service/db/fleet.clj
@@ -1,0 +1,5 @@
+(ns winter-onboarding-2021.fleet-management-service.db.fleet
+  (:require [winter-onboarding-2021.fleet-management-service.db.core :as db]))
+
+(defn create [fleet]
+  (db/insert! :fleets fleet))

--- a/src/winter_onboarding_2021/fleet_management_service/handlers/fleet.clj
+++ b/src/winter_onboarding_2021/fleet_management_service/handlers/fleet.clj
@@ -14,18 +14,17 @@
            :style-class "alert alert-danger"
            :message "Could not create fleet, try again!"}})
 
-(defn create-fleet [req]
-  (let [user-id (get-in req [:user :users/id])
-        fleet-name (get-in req [:form-params :name])
+(defn create-fleet [{:keys [user form-params]}]
+  (let [user-id (:users/id user)
+        fleet-name (:name form-params)
         fleet-data {:name fleet-name
-                    :created-by user-id}
-        valid-fleet-data (s/conform ::specs/create-fleet fleet-data)]
-    (if (s/invalid? valid-fleet-data)
-      (->  error-flash
-           (merge (response/redirect "/fleets/new")))
+                    :created-by user-id}]
+    (if (s/valid? ::specs/fleet-form fleet-data)
       (let [fleet-id (:fleets/id (fleet-model/create fleet-data))]
         (->  success-flash
-             (merge (response/redirect (format "/fleets/%s" (str fleet-id)))))))))
+             (merge (response/redirect (format "/fleets/%s" (str fleet-id))))))
+      (->  error-flash
+           (merge (response/redirect "/fleets/new"))))))
 
 (defn new [_]
   {:title "Create fleet"

--- a/src/winter_onboarding_2021/fleet_management_service/handlers/fleet.clj
+++ b/src/winter_onboarding_2021/fleet_management_service/handlers/fleet.clj
@@ -3,16 +3,9 @@
             [clojure.spec.alpha :as s]
             [winter-onboarding-2021.fleet-management-service.specs :as specs]
             [ring.util.response :as response]
+            [winter-onboarding-2021.fleet-management-service.utils :refer [flash-msg]]
             [winter-onboarding-2021.fleet-management-service.views.fleet :as views]))
 
-(def success-flash
-  {:flash {:success true
-           :style-class "alert alert-success"
-           :message "Fleet created successfully!"}})
-(def error-flash
-  {:flash {:error true
-           :style-class "alert alert-danger"
-           :message "Could not create fleet, try again!"}})
 
 (defn create-fleet [{:keys [user form-params]}]
   (let [user-id (:users/id user)
@@ -21,9 +14,9 @@
                     :created-by user-id}]
     (if (s/valid? ::specs/fleet-form fleet-data)
       (let [fleet-id (:fleets/id (fleet-model/create fleet-data))]
-        (->  success-flash
+        (->  (flash-msg "Fleet created successfully!" true)
              (merge (response/redirect (format "/fleets/%s" (str fleet-id))))))
-      (->  error-flash
+      (->  (flash-msg "Could not create fleet, try again!" false)
            (merge (response/redirect "/fleets/new"))))))
 
 (defn new [_]

--- a/src/winter_onboarding_2021/fleet_management_service/handlers/fleet.clj
+++ b/src/winter_onboarding_2021/fleet_management_service/handlers/fleet.clj
@@ -2,8 +2,8 @@
   (:require [winter-onboarding-2021.fleet-management-service.models.fleet :as fleet-model]
             [clojure.spec.alpha :as s]
             [winter-onboarding-2021.fleet-management-service.specs :as specs]
-            [ring.util.response :as response]))
-
+            [ring.util.response :as response]
+            [winter-onboarding-2021.fleet-management-service.views.fleet :as views]))
 
 (def success-flash
   {:flash {:success true
@@ -22,7 +22,11 @@
         valid-fleet-data (s/conform ::specs/create-fleet fleet-data)]
     (if (s/invalid? valid-fleet-data)
       (->  error-flash
-           (merge (response/redirect "/fleets")))
+           (merge (response/redirect "/fleets/new")))
       (let [fleet-id (:fleets/id (fleet-model/create fleet-data))]
         (->  success-flash
              (merge (response/redirect (format "/fleets/%s" (str fleet-id)))))))))
+
+(defn new [_]
+  {:title "Create fleet"
+   :content (views/create-fleet)})

--- a/src/winter_onboarding_2021/fleet_management_service/handlers/fleet.clj
+++ b/src/winter_onboarding_2021/fleet_management_service/handlers/fleet.clj
@@ -1,0 +1,28 @@
+(ns winter-onboarding-2021.fleet-management-service.handlers.fleet
+  (:require [winter-onboarding-2021.fleet-management-service.models.fleet :as fleet-model]
+            [clojure.spec.alpha :as s]
+            [winter-onboarding-2021.fleet-management-service.specs :as specs]
+            [ring.util.response :as response]))
+
+
+(def success-flash
+  {:flash {:success true
+           :style-class "alert alert-success"
+           :message "Fleet created successfully!"}})
+(def error-flash
+  {:flash {:error true
+           :style-class "alert alert-danger"
+           :message "Could not create fleet, try again!"}})
+
+(defn create-fleet [req]
+  (let [user-id (get-in req [:user :users/id])
+        fleet-name (get-in req [:form-params :name])
+        fleet-data {:name fleet-name
+                    :created-by user-id}
+        valid-fleet-data (s/conform ::specs/create-fleet fleet-data)]
+    (if (s/invalid? valid-fleet-data)
+      (->  error-flash
+           (merge (response/redirect "/fleets")))
+      (let [fleet-id (:fleets/id (fleet-model/create fleet-data))]
+        (->  success-flash
+             (merge (response/redirect (format "/fleets/%s" (str fleet-id)))))))))

--- a/src/winter_onboarding_2021/fleet_management_service/models/fleet.clj
+++ b/src/winter_onboarding_2021/fleet_management_service/models/fleet.clj
@@ -1,0 +1,5 @@
+(ns winter-onboarding-2021.fleet-management-service.models.fleet
+  (:require [winter-onboarding-2021.fleet-management-service.db.fleet :as fleet-db]))
+
+(defn create [fleet]
+  (fleet-db/create fleet))

--- a/src/winter_onboarding_2021/fleet_management_service/routes.clj
+++ b/src/winter_onboarding_2021/fleet_management_service/routes.clj
@@ -38,8 +38,8 @@
                              :post user-handlers/create-user}
                   "/login" {:get (wrap-layout user-handlers/login-form)
                             :post user-handlers/login}}]
-        ["fleets" {"" {:post fleet-handlers/create-fleet}
-                   "/new" {:get (wrap-layout fleet-handlers/new)}}]
+        ["fleets" {"" {:post (authentication-required fleet-handlers/create-fleet #{:admin})}
+                   "/new" {:get (authentication-required (wrap-layout fleet-handlers/new) #{:admin})}}]
         ["healthcheck" {:get (wrap-json-response handler/health-check)}]
         ["index" {:get (wrap-layout handler/index)}]
         ["" {:get (wrap-layout handler/root)}]

--- a/src/winter_onboarding_2021/fleet_management_service/routes.clj
+++ b/src/winter_onboarding_2021/fleet_management_service/routes.clj
@@ -4,6 +4,7 @@
             [ring.middleware.json :refer [wrap-json-response]]
             [hiccup.page :refer [html5]]
             [winter-onboarding-2021.fleet-management-service.handlers.cab :as cab-handlers]
+            [winter-onboarding-2021.fleet-management-service.handlers.fleet :as fleet-handlers]
             [winter-onboarding-2021.fleet-management-service.views.layout :as layout]
             [winter-onboarding-2021.fleet-management-service.handlers.core :as handler]
             [winter-onboarding-2021.fleet-management-service.handlers.user :as user-handlers]))
@@ -37,6 +38,8 @@
                              :post user-handlers/create-user}
                   "/login" {:get (wrap-layout user-handlers/login-form)
                             :post user-handlers/login}}]
+        ["fleets" {"" {:post fleet-handlers/create-fleet}
+                   "/new" {:get (wrap-layout fleet-handlers/new)}}]
         ["healthcheck" {:get (wrap-json-response handler/health-check)}]
         ["index" {:get (wrap-layout handler/index)}]
         ["" {:get (wrap-layout handler/root)}]

--- a/src/winter_onboarding_2021/fleet_management_service/specs.clj
+++ b/src/winter_onboarding_2021/fleet_management_service/specs.clj
@@ -68,3 +68,10 @@
   (s/keys :req-un [:users/email
                    :users/password]))
                    
+; Fleets
+(s/def :fleets/name string?)
+(s/def :fleets/created-by uuid?)
+
+(s/def ::create-fleet
+  (s/keys :req-un [:fleets/name
+                   :fleets/created-by]))

--- a/src/winter_onboarding_2021/fleet_management_service/specs.clj
+++ b/src/winter_onboarding_2021/fleet_management_service/specs.clj
@@ -72,6 +72,6 @@
 (s/def :fleets/name string?)
 (s/def :fleets/created-by uuid?)
 
-(s/def ::create-fleet
+(s/def ::fleet-form
   (s/keys :req-un [:fleets/name
                    :fleets/created-by]))

--- a/src/winter_onboarding_2021/fleet_management_service/views/fleet.clj
+++ b/src/winter_onboarding_2021/fleet_management_service/views/fleet.clj
@@ -1,0 +1,9 @@
+(ns winter-onboarding-2021.fleet-management-service.views.fleet)
+
+(defn create-fleet []
+  [:div {:id "content"}
+   [:h1 {:class "text-success"} "Create Fleet"]
+   [:form {:action "/fleets" :method "POST"}
+    [:div [:label {:for "name" :class "form-label"} "Fleet Name"]
+     [:input {:class "form-control" :type "text" :name "name" :id "name" :value ""}]]
+    [:button {:type "submit" :class "btn btn-primary"} "Submit"]]])

--- a/test/winter_onboarding_2021/fleet_management_service/db/fleet_test.clj
+++ b/test/winter_onboarding_2021/fleet_management_service/db/fleet_test.clj
@@ -2,7 +2,8 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [winter-onboarding-2021.fleet-management-service.db.fleet :as fleet-db]
             [winter-onboarding-2021.fleet-management-service.db.user :as user-db]
-            [winter-onboarding-2021.fleet-management-service.fixtures :as fixtures]))
+            [winter-onboarding-2021.fleet-management-service.fixtures :as fixtures]
+            [winter-onboarding-2021.fleet-management-service.db.core :as db-core]))
 
 (use-fixtures :once fixtures/config fixtures/db-connection)
 (use-fixtures :each fixtures/clear-db)
@@ -16,6 +17,7 @@
           user-id (:users/id (user-db/create user))
           fleet {:name "Azkaban Fleet 1"
                  :created-by user-id}]
+      (fleet-db/create fleet)
       (is (= #:fleets{:name "Azkaban Fleet 1"
-                      :created-by user-id} (select-keys (fleet-db/create fleet)
-                                                        [:fleets/name :fleets/created-by]))))))
+                      :created-by user-id} (select-keys (first (db-core/query! ["select * from fleets;"]))
+                                                        [:fleets/created-by :fleets/name]))))))

--- a/test/winter_onboarding_2021/fleet_management_service/db/fleet_test.clj
+++ b/test/winter_onboarding_2021/fleet_management_service/db/fleet_test.clj
@@ -1,0 +1,21 @@
+(ns winter-onboarding-2021.fleet-management-service.db.fleet-test
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [winter-onboarding-2021.fleet-management-service.db.fleet :as fleet-db]
+            [winter-onboarding-2021.fleet-management-service.db.user :as user-db]
+            [winter-onboarding-2021.fleet-management-service.fixtures :as fixtures]))
+
+(use-fixtures :once fixtures/config fixtures/db-connection)
+(use-fixtures :each fixtures/clear-db)
+
+(deftest create-fleet
+  (testing "Should create a fleet"
+    (let [user {:name "Hermione Granger"
+                :role "admin"
+                :email "hermione@hogwarts.edu"
+                :password "weasley&potter@123"}
+          user-id (:users/id (user-db/create user))
+          fleet {:name "Azkaban Fleet 1"
+                 :created-by user-id}]
+      (is (= #:fleets{:name "Azkaban Fleet 1"
+                      :created-by user-id} (select-keys (fleet-db/create fleet)
+                                                        [:fleets/name :fleets/created-by]))))))

--- a/test/winter_onboarding_2021/fleet_management_service/fixtures.clj
+++ b/test/winter_onboarding_2021/fleet_management_service/fixtures.clj
@@ -22,5 +22,5 @@
   (mount/stop #'db/db-conn))
 
 (defn clear-db [f]
-  (jdbc/execute! db/db-conn  ["TRUNCATE TABLE cabs, sessions, users CASCADE"])
+  (jdbc/execute! db/db-conn  ["TRUNCATE TABLE cabs, sessions, users, fleets CASCADE"])
   (f))

--- a/test/winter_onboarding_2021/fleet_management_service/handlers/fleet_test.clj
+++ b/test/winter_onboarding_2021/fleet_management_service/handlers/fleet_test.clj
@@ -1,0 +1,28 @@
+(ns winter-onboarding-2021.fleet-management-service.handlers.fleet-test
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [winter-onboarding-2021.fleet-management-service.fixtures :as fixtures]
+            [winter-onboarding-2021.fleet-management-service.handlers.fleet :as fleet-handler]
+            [winter-onboarding-2021.fleet-management-service.db.core :as db-core]
+            [winter-onboarding-2021.fleet-management-service.db.user :as user-db]))
+
+(use-fixtures :once fixtures/config fixtures/db-connection)
+(use-fixtures :each fixtures/clear-db)
+
+(deftest create-fleet
+  (testing "Should create a fleet by an admin"
+    (let [user {:name "foo bar"
+                :role "admin"
+                :email "foobar@gmail.com"
+                :password "foo"}
+          user-id (:users/id (user-db/create user))
+          request {:form-params {:name "Goo fleet"}
+                   :user #:users{:id user-id
+                                 :name "foo bar"
+                                 :role "admin"
+                                 :email "foobar@gmail.com"}}
+          response (fleet-handler/create-fleet request)
+          inserted-fleet (first (db-core/query! ["SELECT * FROM FLEETS"]))]
+      (is (= 302 (:status response)))
+      (is (= #:fleets{:name "Goo fleet"
+                      :created-by user-id} (select-keys inserted-fleet 
+                                                        [:fleets/name :fleets/created-by]))))))

--- a/test/winter_onboarding_2021/fleet_management_service/handlers/fleet_test.clj
+++ b/test/winter_onboarding_2021/fleet_management_service/handlers/fleet_test.clj
@@ -25,4 +25,16 @@
       (is (= 302 (:status response)))
       (is (= #:fleets{:name "Goo fleet"
                       :created-by user-id} (select-keys inserted-fleet 
-                                                        [:fleets/name :fleets/created-by]))))))
+                                                        [:fleets/name :fleets/created-by])))
+      (is (= {:success true
+              :style-class "alert alert-success"
+              :message "Fleet created successfully!"} (:flash response)))))
+  
+  (testing "Should not create a fleet if the admin is not logged-in"
+    (let [request {:form-params {:name "Boo fleet"}}
+          response (fleet-handler/create-fleet request)]
+      (is (= 302 (:status response)))
+      (is (= {"Location" "/fleets/new"} (:headers response) ))
+      (is (= {:error true
+              :style-class "alert alert-danger"
+              :message "Could not create fleet, try again!"} (:flash response))))))

--- a/test/winter_onboarding_2021/fleet_management_service/models/fleet_test.clj
+++ b/test/winter_onboarding_2021/fleet_management_service/models/fleet_test.clj
@@ -1,0 +1,21 @@
+(ns winter-onboarding-2021.fleet-management-service.models.fleet-test
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [winter-onboarding-2021.fleet-management-service.models.fleet :as fleet-model]
+            [winter-onboarding-2021.fleet-management-service.db.user :as user-db]
+            [winter-onboarding-2021.fleet-management-service.fixtures :as fixtures]))
+
+(use-fixtures :once fixtures/config fixtures/db-connection)
+(use-fixtures :each fixtures/clear-db)
+
+(deftest create-fleet
+  (testing "Should create a fleet"
+    (let [user {:name "Hermione Granger"
+                :role "admin"
+                :email "hermione@hogwarts.edu"
+                :password "weasley&potter@123"}
+          user-id (:users/id (user-db/create user))
+          fleet {:name "Azkaban Fleet 1"
+                 :created-by user-id}]
+      (is (= #:fleets{:name "Azkaban Fleet 1"
+                      :created-by user-id} (select-keys (fleet-model/create fleet)
+                                                        [:fleets/name :fleets/created-by]))))))


### PR DESCRIPTION
`create-fleet` depends on login #47 implementation. 
Right now, a fleet could not be created, since it expects to get user-id (logged-in user-id) which is implemented in login branch.
Depends on #47 