### PR TITLE
Generalise factories

### DIFF
--- a/doc/arch/ADR-003.md
+++ b/doc/arch/ADR-003.md
@@ -1,0 +1,27 @@
+# Title
+Passing spec generator to generalised factory will generate and create data in the DB
+
+# Context
+While writing tests, we generally need to generate & insert sample data in the database to test our code's behaviour.
+
+It is crucial that these factories provide us an easy, intuitive and flexible way of generated  & inserting data into DB.
+Ideally, these factories should also provide us a way for supplying override values.
+
+Earlier, we made factories for each model seprately & they only generated data(not inserted them).
+It was getting a little cumbersome to write tests using the above factories because of much repetitive code.
+
+The new factories will accept a spec generator & a table name where the generated data will be inserted.
+
+# Decision
+It has been decided to move ahead with generalising the factories
+
+# Status
+Accepted
+
+# Consequences
+Pros:
+Easy API for genrating variety of data and inserting it in database
+
+Cons:
+It still doesn't solve for creating associations between different entities.
+We will have to do it manually just like we did before.

--- a/src/winter_onboarding_2021/fleet_management_service/handlers/fleet.clj
+++ b/src/winter_onboarding_2021/fleet_management_service/handlers/fleet.clj
@@ -11,7 +11,7 @@
   (let [user-id (:users/id user)
         fleet-name (:name form-params)
         fleet-data (namespace-keys :fleets {:name fleet-name
-                                      :created-by user-id})]
+                                            :created-by user-id})]
     (if (s/valid? ::specs/fleets fleet-data)
       (let [fleet-id (:fleets/id (fleet-model/create fleet-data))]
         (->  (flash-msg "Fleet created successfully!" true)

--- a/test/winter_onboarding_2021/fleet_management_service/db/fleet_test.clj
+++ b/test/winter_onboarding_2021/fleet_management_service/db/fleet_test.clj
@@ -1,33 +1,27 @@
 (ns winter-onboarding-2021.fleet-management-service.db.fleet-test
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
-            [winter-onboarding-2021.fleet-management-service.db.fleet :as fleet-db]
-            [winter-onboarding-2021.fleet-management-service.db.user :as user-db]
+            [clojure.spec.alpha :as s]
+            [clojure.spec.gen.alpha :as gen]
+            [winter-onboarding-2021.fleet-management-service.factories :as factories]
+            [winter-onboarding-2021.fleet-management-service.specs :as specs]
             [winter-onboarding-2021.fleet-management-service.fixtures :as fixtures]
             [winter-onboarding-2021.fleet-management-service.db.core :as db-core]
-            [winter-onboarding-2021.fleet-management-service.error :as error]))
+            [winter-onboarding-2021.fleet-management-service.error :as error]
+            [winter-onboarding-2021.fleet-management-service.db.fleet :as fleet-db]))
 
 (use-fixtures :once fixtures/config fixtures/db-connection)
 (use-fixtures :each fixtures/clear-db)
 
 (deftest create-fleet
   (testing "Should create a fleet"
-    (let [user {:users/name "Hermione Granger"
-                :users/role "admin"
-                :users/email "hermione@hogwarts.edu"
-                :users/password "weasley&potter@123"}
-          user-id (:users/id (user-db/create user))
-          fleet {:fleets/name "Azkaban Fleet 1"
-                 :fleets/created-by user-id}]
-      (fleet-db/create fleet)
-      (is (= #:fleets{:name "Azkaban Fleet 1"
-                      :created-by user-id} (select-keys (first (db-core/query! ["select * from fleets;"]))
-                                                        [:fleets/created-by :fleets/name])))))
+    (let [user-id (:users/id (factories/create :users (s/gen ::specs/users)))
+          fleet (factories/create :fleets (gen/fmap #(assoc % :fleets/created-by user-id)
+                                                    (s/gen ::specs/fleets)))]
+
+      (is (= fleet (first (db-core/query! ["select * from fleets;"]))))))
+
   (testing "Should not create a fleet if create-by is not uuid"
-    (let [user {:users/name "Hermione Granger"
-                :users/role "admin"
-                :users/email "hermione@hogwart.edu"
-                :users/password "weasley&potter@123"}
-          user-id (:users/id (user-db/create user))
+    (let [user-id (:users/id (factories/create :users (s/gen ::specs/users)))
           fleet {:fleets/name "Azkaban Fleet 1"
                  :fleets/created-by (str user-id)}]
       (is (= error/validation-failed (select-keys (fleet-db/create fleet) [:error]))))))

--- a/test/winter_onboarding_2021/fleet_management_service/db/session_test.clj
+++ b/test/winter_onboarding_2021/fleet_management_service/db/session_test.clj
@@ -1,10 +1,11 @@
 (ns winter-onboarding-2021.fleet-management-service.db.session-test
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [clojure.spec.alpha :as s]
+            [winter-onboarding-2021.fleet-management-service.specs :as specs]
             [winter-onboarding-2021.fleet-management-service.db.core :as db-core]
             [winter-onboarding-2021.fleet-management-service.fixtures :as fixtures]
             [winter-onboarding-2021.fleet-management-service.factories :as factories]
             [winter-onboarding-2021.fleet-management-service.db.session :as db-session]
-            [winter-onboarding-2021.fleet-management-service.models.user :as user-models]
             [winter-onboarding-2021.fleet-management-service.utils :as utils]
             [winter-onboarding-2021.fleet-management-service.config :as config]))
 
@@ -13,9 +14,8 @@
 
 (deftest lookup
   (testing "Should return us user id associated with a given session-id"
-    (let [user (factories/user)
-          created-user (user-models/create user)
-          user-id (:users/id created-user)
+    (let [user (factories/create :users (s/gen ::specs/users))
+          user-id (:users/id user)
           session-id (utils/uuid)
           created-session (db-core/insert! :sessions {:id session-id
                                                       :user-id user-id
@@ -25,9 +25,8 @@
 
 (deftest insert
   (testing "Should add a session in the sessions table"
-    (let [user (factories/user)
-          created-user (user-models/create user)
-          user-id (:users/id created-user)
+    (let [user (factories/create :users (s/gen ::specs/users))
+          user-id (:users/id user)
           session-id (utils/uuid)
           created-session (db-session/insert session-id user-id)]
 
@@ -36,9 +35,8 @@
 
 (deftest delete
   (testing "Should delete the session given a session id"
-    (let [user (factories/user)
-          created-user (user-models/create user)
-          user-id (:users/id created-user)
+    (let [user (factories/create :users (s/gen ::specs/users))
+          user-id (:users/id user)
           session-id (utils/uuid)
           _ (db-session/insert session-id user-id)]
       (db-session/delete session-id)
@@ -46,13 +44,12 @@
 
 (deftest user-session
   (testing "Should give us details about the session & the user associated with it"
-    (let [user (factories/user)
-          created-user (user-models/create user)
-          user-id (:users/id created-user)
+    (let [user (factories/create :users (s/gen ::specs/users))
+          user-id (:users/id user)
           session-id (utils/uuid)
           created-session (db-session/insert session-id user-id)
           joined-user-session (first (db-session/user-session session-id))]
-      (is (= (select-keys (merge created-user created-session)
+      (is (= (select-keys (merge user created-session)
                           [:users/id :users/name :users/role :users/email
                            :sessions/id :sessions/expires-at])
              joined-user-session)))))

--- a/test/winter_onboarding_2021/fleet_management_service/factories.clj
+++ b/test/winter_onboarding_2021/fleet_management_service/factories.clj
@@ -1,7 +1,15 @@
 (ns winter-onboarding-2021.fleet-management-service.factories
   (:require [clojure.spec.gen.alpha :as gen]
             [clojure.spec.alpha :as s]
+            [winter-onboarding-2021.fleet-management-service.db.core :as db-core]
             [winter-onboarding-2021.fleet-management-service.specs :as specs]))
+
+(defn create [table generator]
+  (db-core/insert! table (gen/generate generator)))
+
+(defn create-list [table count generator]
+  (doall (map #(db-core/insert! table %)
+              (gen/sample generator count))))
 
 (defn generate-cab [num]
   (s/gen (s/coll-of ::specs/cabs
@@ -17,8 +25,10 @@
 
 (defn admin
   ([] (admin {}))
-  ([overrides] (user (merge overrides {:users/role "admin"}))))
+  ([overrides] (create :users (gen/fmap #(merge % overrides {:users/role "admin"})
+                                        (s/gen ::specs/users)))))
 
 (defn manager
   ([] (manager {}))
-  ([overrides] (user (merge overrides {:users/role "manager"}))))
+  ([overrides] (create :users (gen/fmap #(merge % overrides {:users/role "manager"})
+                                        (s/gen ::specs/users)))))

--- a/test/winter_onboarding_2021/fleet_management_service/handlers/fleet_test.clj
+++ b/test/winter_onboarding_2021/fleet_management_service/handlers/fleet_test.clj
@@ -1,40 +1,34 @@
 (ns winter-onboarding-2021.fleet-management-service.handlers.fleet-test
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [winter-onboarding-2021.fleet-management-service.factories :as factories]
             [winter-onboarding-2021.fleet-management-service.fixtures :as fixtures]
             [winter-onboarding-2021.fleet-management-service.handlers.fleet :as fleet-handler]
-            [winter-onboarding-2021.fleet-management-service.db.core :as db-core]
-            [winter-onboarding-2021.fleet-management-service.db.user :as user-db]))
+            [winter-onboarding-2021.fleet-management-service.db.core :as db-core]))
 
 (use-fixtures :once fixtures/config fixtures/db-connection)
 (use-fixtures :each fixtures/clear-db)
 
 (deftest create-fleet
   (testing "Should create a fleet by an admin"
-    (let [user {:users/name "foo bar"
-                :users/role "admin"
-                :users/email "foobar@gmail.com"
-                :users/password "foo"}
-          user-id (:users/id (user-db/create user))
+    (let [user (factories/admin)
+          user-id (:users/id user)
           request {:form-params {:name "Goo fleet"}
-                   :user #:users{:id user-id
-                                 :name "foo bar"
-                                 :role "admin"
-                                 :email "foobar@gmail.com"}}
+                   :user user}
           response (fleet-handler/create-fleet request)
           inserted-fleet (first (db-core/query! ["SELECT * FROM FLEETS"]))]
       (is (= 302 (:status response)))
       (is (= #:fleets{:name "Goo fleet"
-                      :created-by user-id} (select-keys inserted-fleet 
+                      :created-by user-id} (select-keys inserted-fleet
                                                         [:fleets/name :fleets/created-by])))
       (is (= {:success true
               :style-class "alert alert-success"
               :message "Fleet created successfully!"} (:flash response)))))
-  
+
   (testing "Should not create a fleet if the admin is not logged-in"
     (let [request {:form-params {:name "Boo fleet"}}
           response (fleet-handler/create-fleet request)]
       (is (= 302 (:status response)))
-      (is (= {"Location" "/fleets/new"} (:headers response) ))
+      (is (= {"Location" "/fleets/new"} (:headers response)))
       (is (= {:error true
               :style-class "alert alert-danger"
               :message "Could not create fleet, try again!"} (:flash response))))))

--- a/test/winter_onboarding_2021/fleet_management_service/models/fleet_test.clj
+++ b/test/winter_onboarding_2021/fleet_management_service/models/fleet_test.clj
@@ -1,7 +1,7 @@
 (ns winter-onboarding-2021.fleet-management-service.models.fleet-test
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [winter-onboarding-2021.fleet-management-service.factories :as factories]
             [winter-onboarding-2021.fleet-management-service.models.fleet :as fleet-model]
-            [winter-onboarding-2021.fleet-management-service.db.user :as user-db]
             [winter-onboarding-2021.fleet-management-service.error :as error]
             [winter-onboarding-2021.fleet-management-service.fixtures :as fixtures]))
 
@@ -10,22 +10,16 @@
 
 (deftest create-fleet
   (testing "Should create a fleet"
-    (let [user {:users/name "Hermione Granger"
-                :users/role "admin"
-                :users/email "hermione@hogwarts.edu"
-                :users/password "weasley&potter@123"}
-          user-id (:users/id (user-db/create user))
-          fleet {:fleets/name "Azkaban Fleet 1"
-                 :fleets/created-by user-id}]
-      (is (= #:fleets{:name "Azkaban Fleet 1"
-                      :created-by user-id} (select-keys (fleet-model/create fleet)
-                                                        [:fleets/name :fleets/created-by])))))
+    (let [user (factories/admin)
+          user-id (:users/id user)
+          fleet #:fleets{:name "Azkaban Fleet 1"
+                         :created-by user-id}]
+      (is (= fleet
+             (select-keys (fleet-model/create fleet)
+                          [:fleets/name :fleets/created-by])))))
   (testing "Should ignore un-related keys while creating a fleet"
-    (let [user {:users/name "Hermione Granger"
-                :users/role "admin"
-                :users/email "hermione@hogwart.edu"
-                :users/password "weasley&potter@123"}
-          user-id (:users/id (user-db/create user))
+    (let [user (factories/admin)
+          user-id (:users/id user)
           fleet {:fleets/name "Azkaban Fleet 1"
                  :fleets/place "Azkaban"
                  :fleets/created-by user-id}]
@@ -33,11 +27,8 @@
                       :created-by user-id} (select-keys (fleet-model/create fleet)
                                                         [:fleets/name :fleets/created-by])))))
   (testing "Should not create a fleet if all keys are un-related"
-    (let [user {:users/name "Ron Weasley"
-                :users/role "admin"
-                :users/email "ron@hogwart.edu"
-                :users/password "hermionie&potter@123"}
-          user-id (:users/id (user-db/create user))
+    (let [user (factories/admin)
+          user-id (:users/id user)
           fleet {:fleets/place "Azkaban Fleet 1"
                  :fleets/admin (str user-id)}]
       (is (= error/no-valid-keys (fleet-model/create fleet))))))

--- a/test/winter_onboarding_2021/fleet_management_service/models/user_test.clj
+++ b/test/winter_onboarding_2021/fleet_management_service/models/user_test.clj
@@ -1,39 +1,33 @@
 (ns winter-onboarding-2021.fleet-management-service.models.user-test
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [crypto.password.bcrypt :as password]
+            [winter-onboarding-2021.fleet-management-service.factories :as factories]
             [winter-onboarding-2021.fleet-management-service.models.user :as user-model]
             [winter-onboarding-2021.fleet-management-service.fixtures :as fixtures]))
 
 (use-fixtures :once fixtures/config fixtures/db-connection)
 (use-fixtures :each fixtures/clear-db)
 
-(deftest create-cab
-  (testing "Should create a cab"
-    (let [user {:users/name "Harry Potter"
-                :users/role "admin"
-                :users/email "harry@hogwarts.edu"
-                :users/password "hermione@123"}
+(defn select-relevant-keys [user]
+  (select-keys user [:users/name :users/email :users/password :users/role]))
+
+(deftest create-user
+  (testing "Should create a user"
+    (let [user #:users{:name "Harry Potter"
+                       :role "admin"
+                       :email "harry@hogwarts.edu"
+                       :password "hermione@123"}
           _ (user-model/create user)]
-      (is (= #:users{:name "Harry Potter"
-                     :role "admin"
-                     :email "harry@hogwarts.edu"
-                     :password "hermione@123"}
-             (select-keys (first (user-model/find-by-keys {:users/email (:users/email user)}))
-                          [:users/name :users/role :users/email :users/password]))))))
+      (is (= (select-relevant-keys user)
+             (select-relevant-keys (first (user-model/find-by-keys
+                                           {:users/email (:users/email user)}))))))))
 
 (deftest find-by-keys
   (testing "Should return a user given a key-map(properties)"
-    (let [user {:users/name "Harry Potter"
-                :users/role "admin"
-                :users/email "harry@hogwarts.edu"
-                :users/password "hermione@123"}
-          _ (user-model/create user)]
-      (is (= #:users{:name "Harry Potter"
-                     :role "admin"
-                     :email "harry@hogwarts.edu"
-                     :password "hermione@123"}
-             (select-keys (first (user-model/find-by-keys {:users/email (:users/email user)}))
-                          [:users/name :users/role :users/email :users/password]))))))
+    (let [user (factories/admin)]
+      (is (= (select-relevant-keys user)
+             (select-relevant-keys (first (user-model/find-by-keys
+                                           {:users/email (:users/email user)}))))))))
 
 (deftest authenticate
   (testing "Correct login credentials, should return us user data"


### PR DESCRIPTION
The previous factories required generating the mock data and then writing another line for inserting them in database.

New factory `create` abstracts that part out. They now just take a spec gen & then generates + inserts data in DB